### PR TITLE
OPENOLT_PROTO_VER updated to 5.4.6, applying debian stretch mirror patch

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -196,7 +196,7 @@ tag/branch corresponding to that specific version:
 make OPENOLTDEVICE=asfvolt16 OPENOLT_PROTO_VER=master
 ```
 
-By default, the `OPENOLT_PROTO_VER` defaults to git tag *v5.2.1* of the
+By default, the `OPENOLT_PROTO_VER` defaults to git tag *v5.4.6* of the
 [voltha-protos](https://gerrit.opencord.org/gitweb?p=voltha-protos.git;a=summary)
 repo.
 
@@ -333,7 +333,7 @@ tag/branch corresponding to that specific version:
 make OPENOLTDEVICE=rlt-3200g-w OPENOLT_PROTO_VER=master
 ```
 
-By default, the `OPENOLT_PROTO_VER` defaults to git tag *v5.2.1* of the
+By default, the `OPENOLT_PROTO_VER` defaults to git tag *v5.4.6* of the
 [voltha-protos](https://gerrit.opencord.org/gitweb?p=voltha-protos.git;a=summary)
 repo.
 
@@ -431,7 +431,7 @@ tag/branch corresponding to that specific version:
 make OPENOLTDEVICE=sda3016ss OPENOLT_PROTO_VER=master
 ```
 
-By default, the `OPENOLT_PROTO_VER` defaults to git tag *v5.2.1* of the
+By default, the `OPENOLT_PROTO_VER` defaults to git tag *v5.4.6* of the
 [voltha-protos](https://gerrit.opencord.org/gitweb?p=voltha-protos.git;a=summary)
 repo.
 

--- a/agent/Makefile.in
+++ b/agent/Makefile.in
@@ -52,7 +52,7 @@ SDK_VER = 6.5.21
 # This specifies the GIT tag in https://github.com/opencord/voltha-protos
 # repo that we need to refer to, to pick the right version of
 # openolt.proto and tech_profile.proto
-OPENOLT_PROTO_VER ?= v5.2.1
+OPENOLT_PROTO_VER ?= v5.4.6
 
 # Variables used for Inband build
 INBAND = "n"
@@ -159,6 +159,7 @@ onl:
 			cp download/Makefile.onl $(ONL_DIR)/Makefile; \
 			install -m 755 download/build-onl.sh $(ONL_DIR)/OpenNetworkLinux; \
 			cp download/disable-certificate-validation*.patch $(ONL_DIR)/OpenNetworkLinux; \
+			cp download/debian_stretch_mirror.patch $(ONL_DIR)/OpenNetworkLinux; \
 			if [ "$(OPENOLTDEVICE)" = "rlt-3200g-w" ] || [ "$(OPENOLTDEVICE)" = "rlt-1600g-w" ] || [ "$(OPENOLTDEVICE)" = "rlt-1600x-w" ]; \
 			then \
 				cp $(TOP_DIR)/device/$(OPENOLTDEVICE)/update_kernel_options.sh $(ONL_DIR)/OpenNetworkLinux/.; \

--- a/agent/download/Makefile.onl
+++ b/agent/download/Makefile.onl
@@ -17,6 +17,7 @@ RLT_COMMIT_ID = 72b95a7
 INBAND = "n"
 BOARD = ""
 
+
 onl-4.14:
 	if [ $(INBAND) = y ]; then \
 	    cd OpenNetworkLinux && git checkout -B $@ $(COMMIT_ID) && git pull origin pull/822/head -ff -q --no-edit && git apply disable-certificate-validation-v$(COMMIT_ID).patch && git apply inband-$(COMMIT_ID).patch && docker/tools/onlbuilder --non-interactive -8 -c ./build-onl.sh; \
@@ -25,7 +26,7 @@ onl-4.14:
 	fi;
 onl-4.19:
 	if [ "$(BOARD)" = "rlt-3200g-w" ] || [ "$(BOARD)" = "rlt-1600g-w" ] || [ "$(BOARD)" = "rlt-1600x-w" ]; then \
-		cd OpenNetworkLinux && git stash && git checkout -B $@ $(RLT_COMMIT_ID) && git apply disable-certificate-validation-v$(RLT_COMMIT_ID).patch && bash update_kernel_options.sh && docker/tools/onlbuilder --non-interactive -9 -c ./build-onl.sh; \
+		cd OpenNetworkLinux && git stash && git checkout -B $@ $(RLT_COMMIT_ID) && git apply disable-certificate-validation-v$(RLT_COMMIT_ID).patch && bash update_kernel_options.sh && git apply debian_stretch_mirror.patch && docker/tools/onlbuilder --non-interactive -9 -c ./build-onl.sh; \
 	else \
-		cd OpenNetworkLinux && git stash && git checkout -B $@ $(COMMIT_ID) && git pull origin pull/822/head -ff -q --no-edit && git apply disable-certificate-validation-v$(COMMIT_ID).patch && docker/tools/onlbuilder --non-interactive -9 -c ./build-onl.sh; \
+		cd OpenNetworkLinux && git stash && git checkout -B $@ $(COMMIT_ID) && git pull origin pull/822/head -ff -q --no-edit && git apply disable-certificate-validation-v$(COMMIT_ID).patch && git apply debian_stretch_mirror.patch && docker/tools/onlbuilder --non-interactive -9 -c ./build-onl.sh; \
 	fi;

--- a/agent/download/debian_stretch_mirror.patch
+++ b/agent/download/debian_stretch_mirror.patch
@@ -1,0 +1,13 @@
+diff --git a/tools/onlrfs.py b/tools/onlrfs.py
+index a9a4cb5d..051259d0 100755
+--- a/tools/onlrfs.py
++++ b/tools/onlrfs.py
+@@ -302,7 +302,7 @@ class OnlRfsBuilder(object):
+ 
+     DEFAULTS = dict(
+         DEBIAN_SUITE='wheezy',
+-        DEBIAN_MIRROR='mirrors.kernel.org/debian/',
++        DEBIAN_MIRROR='archive.debian.org/debian/',
+         APT_CACHE='127.0.0.1:3142/'
+         )
+ 


### PR DESCRIPTION
Hi!
The contribution link is dead, therefore I do it still here on Github to inform you about the changes you may want to do.

Related to issue #6 I found out that the compilation of the agent fails as the version of download Protofiles is to old. Updating the versions number solved the problem.
Also when compiling the ONL, apt update fails as the mirror is broken for debian stretch. I introduced a patch to fix the mirror in the dynamically downloaded ONL while building.

-----------------------------
Welcome to OpenCORD!

And thanks for contribute to the project!

Unluckily OpenCORD uses github.com only to mirror repositories,
to contribute to the project please visit this page:
https://guide.opencord.org/developer/getting_the_code.html#contributing-code-to-cord
